### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,5 @@
   "engines": {
     "node": ">= 0.8"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/robrich/pretty-hrtime/raw/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
