### PR TITLE
Fix regression caused by Node v5.4 hrtime patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - "5.4"

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var verboseDesc = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'na
 var convert = [60*60, 60, 1, 1e6, 1e3, 1];
 
 module.exports = function (source, opts) {
-	var verbose, precise, i, spot, sourceAtStep, valAtStep, decimals, strAtStep, results;
+	var verbose, precise, i, spot, sourceAtStep, valAtStep, decimals, strAtStep, results, totalSeconds;
 
 	verbose = false;
 	precise = false;
@@ -21,6 +21,13 @@ module.exports = function (source, opts) {
 	}
 	if (typeof source[0] !== 'number' || typeof source[1] !== 'number') {
 		return '';
+	}
+
+	// normalize source array due to changes in node v5.4+
+	if (source[1] < 0) {
+		totalSeconds = source[0] + source[1] / 1e9;
+		source[0] = parseInt(totalSeconds);
+		source[1] = parseFloat((totalSeconds % 1).toPrecision(9)) * 1e9;
 	}
 
 	results = '';

--- a/test/minimal.js
+++ b/test/minimal.js
@@ -62,5 +62,17 @@ describe('pretty-hrtime', function() {
 			runTest('600 ns', [0, 600]);
 		});
 
+		// Node v5.4+ negative nano values
+		it('31s', function() {
+			runTest('31 s', [31, -97909258]);
+		});
+
+		it('2.9s', function() {
+			runTest('2.9 s', [3, -95038258]);
+		});
+
+		it('603ms', function() {
+			runTest('603 ms', [1, -396570776]);
+		});
 	});
 });

--- a/test/precise.js
+++ b/test/precise.js
@@ -62,5 +62,17 @@ describe('pretty-hrtime', function() {
 			runTest('600 ns', [0, 600]);
 		});
 
+		// Node v5.4+ negative nano values
+		it('31s', function() {
+			runTest('30.902090742 s', [31, -97909258]);
+		});
+
+		it('2.9s', function() {
+			runTest('2.9049617420000002 s', [3, -95038258]);
+		});
+
+		it('603ms', function() {
+			runTest('603.429224 ms', [1, -396570776]);
+		});
 	});
 });

--- a/test/verbose.js
+++ b/test/verbose.js
@@ -70,5 +70,17 @@ describe('pretty-hrtime', function() {
 			runTest('600 nanoseconds', [0, 600]);
 		});
 
+		// Node v5.4+ negative nano values
+		it('31s', function() {
+			runTest('30 seconds 902 milliseconds 90 microseconds 742 nanoseconds', [31, -97909258]);
+		});
+
+		it('2.9s', function() {
+			runTest('2 seconds 904 milliseconds 961 microseconds 742 nanoseconds', [3, -95038258]);
+		});
+
+		it('603ms', function() {
+			runTest('603 milliseconds 429 microseconds 224 nanoseconds', [1, -396570776]);
+		});
 	});
 });


### PR DESCRIPTION
This came about because I noticed that sometimes certain tasks would not show the finished output time (pretty-hrtime was returning an empty string).

[Node v5.4](https://github.com/nodejs/node/blob/master/CHANGELOG.md) changed `process.hrtime` so it can now return negative nanosecond values in cases where seconds are > 0.  Essentially, instead of representing 30.9 seconds as `[30, 9e8]` it will instead represent it as `[31, -1e8]`. The resulting total is the same, but it breaks this module.

This patch checks for negative values in the second position, and it they exist, it normalizes the source.  Tests are using actual values derived from using (e.g.):

``` js
let t = process.hrtime();
setTimeout(() => console.log(process.hrtime(t)), 6990);
```

If you'd like we can change them to be simplified.
